### PR TITLE
Refactor: 판매자 이름 리스트 조회 API 작성 #KOK-98

### DIFF
--- a/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
+++ b/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
@@ -1,6 +1,7 @@
 package shop.kokodo.sellerservice.controller;
 
-import feign.Param;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import shop.kokodo.sellerservice.dto.response.Response;
 import shop.kokodo.sellerservice.service.SellerService;
 
 @RestController
@@ -26,5 +28,11 @@ public class SellerController {
         boolean flag = sellerService.findBySellerId(id).isEmpty()? false : true ;
 
         return ResponseEntity.status(HttpStatus.OK).body(flag);
+    }
+
+    @GetMapping("/names")
+    public Response getSellerName(@RequestParam List<Long> sellerIds) {
+        Map<Long, String> sellerNameMap = sellerService.getSellerNames(sellerIds);
+        return Response.success(sellerNameMap);
     }
 }

--- a/src/main/java/shop/kokodo/sellerservice/repository/SellerRepository.java
+++ b/src/main/java/shop/kokodo/sellerservice/repository/SellerRepository.java
@@ -1,5 +1,6 @@
 package shop.kokodo.sellerservice.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.kokodo.sellerservice.entity.Seller;
 
@@ -16,5 +17,6 @@ import shop.kokodo.sellerservice.entity.Seller;
  */
 public interface SellerRepository extends JpaRepository<Seller, Long> {
 
+    <T> List<T> findByIdIn(List<Long> ids, Class<T> type);
 
 }

--- a/src/main/java/shop/kokodo/sellerservice/repository/interfaces/SellerName.java
+++ b/src/main/java/shop/kokodo/sellerservice/repository/interfaces/SellerName.java
@@ -1,0 +1,8 @@
+package shop.kokodo.sellerservice.repository.interfaces;
+
+public interface SellerName {
+
+    Long getId();
+    String getName();
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
@@ -1,5 +1,7 @@
 package shop.kokodo.sellerservice.service;
 
+import java.util.List;
+import java.util.Map;
 import shop.kokodo.sellerservice.entity.Seller;
 
 import java.util.Optional;
@@ -7,4 +9,6 @@ import java.util.Optional;
 public interface SellerService {
 
     public Optional<Seller> findBySellerId(Long sellerId);
+
+    public Map<Long, String> getSellerNames(List<Long> sellerIds);
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
@@ -1,11 +1,14 @@
 package shop.kokodo.sellerservice.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import shop.kokodo.sellerservice.entity.Seller;
 import shop.kokodo.sellerservice.repository.SellerRepository;
-
-import java.util.Optional;
+import shop.kokodo.sellerservice.repository.interfaces.SellerName;
 
 @Service
 public class SellerServiceImpl implements SellerService{
@@ -20,5 +23,11 @@ public class SellerServiceImpl implements SellerService{
     @Override
     public Optional<Seller> findBySellerId(Long sellerId) {
         return sellerRepository.findById(sellerId);
+    }
+
+    @Override
+    public Map<Long, String> getSellerNames(List<Long> sellerIds) {
+        List<SellerName> sellerNames = sellerRepository.findByIdIn(sellerIds, SellerName.class);
+        return sellerNames.stream().collect(Collectors.toMap(SellerName::getId, SellerName::getName));
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,11 @@
-insert into seller(created_date, last_modified_date, seller_id, user_long_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
+insert into seller(created_date, last_modified_date, seller_id, user_login_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
 values(now(), now(),1, "namhyeop1", "!namhyeop1234", "010-3333-3333",
        "namhyeop@gmail.com", true, true, "1996-12-12",
        "KIMNAMHYEOP", 100000, "서울특별시 강남구", "서울특별시 강동구",
        "롯데택배", "롯데택배", true, true,
        "VIP");
 
-insert into seller(created_date, last_modified_date, seller_id, user_long_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
+insert into seller(created_date, last_modified_date, seller_id, user_login_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
 values(now(), now(),2, "namhyeop2", "!namhyeop1234", "010-3333-3333",
        "namhyeop@gmail.com", true, true, "1996-12-12",
        "KIMNAMHYEOP2", 100000, "서울특별시 강남구", "서울특별시 강동구",


### PR DESCRIPTION
- 프론트에서 판매자 별 장바구니 상품 출력 시 판매자 이름 필요
- DB에서 필요한 속성(seller name) 만 조회하도록 Spring Data JPA Projection 사용
- data.sql: 판매자 login_id 오타 수정