### PR TITLE
Feat: Seller 인증 구현, Seller data.sql 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // spring security, jwt
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
     //RabbitMQ
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
 

--- a/src/main/java/shop/kokodo/sellerservice/SellerServiceApplication.java
+++ b/src/main/java/shop/kokodo/sellerservice/SellerServiceApplication.java
@@ -7,10 +7,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableJpaAuditing
 public class SellerServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
+++ b/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
@@ -1,13 +1,17 @@
 package shop.kokodo.sellerservice.controller;
 
-import feign.Param;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import shop.kokodo.sellerservice.dto.SignupRequest;
+import shop.kokodo.sellerservice.dto.response.Response;
+import shop.kokodo.sellerservice.entity.Seller;
 import shop.kokodo.sellerservice.service.SellerService;
 
 @RestController
@@ -26,5 +30,14 @@ public class SellerController {
         boolean flag = sellerService.findBySellerId(id).isEmpty()? false : true ;
 
         return ResponseEntity.status(HttpStatus.OK).body(flag);
+    }
+
+    /**
+     * 셀러 생성을 위해 사용하는 API
+     */
+    @PostMapping("/signup")
+    public Response signup(@RequestBody SignupRequest req) {
+        Seller seller = sellerService.createSeller(req);
+        return Response.success();
     }
 }

--- a/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
+++ b/src/main/java/shop/kokodo/sellerservice/controller/SellerController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,5 +40,11 @@ public class SellerController {
     public Response signup(@RequestBody SignupRequest req) {
         Seller seller = sellerService.createSeller(req);
         return Response.success();
+    }
+
+    @GetMapping("/name")
+    public Response getSellerName(@RequestHeader Long sellerId) {
+        String name = sellerService.getSellerName(sellerId);
+        return Response.success(name);
     }
 }

--- a/src/main/java/shop/kokodo/sellerservice/dto/LoginRequest.java
+++ b/src/main/java/shop/kokodo/sellerservice/dto/LoginRequest.java
@@ -1,0 +1,15 @@
+package shop.kokodo.sellerservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    private String loginId;
+    private String password;
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/dto/LoginResponse.java
+++ b/src/main/java/shop/kokodo/sellerservice/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package shop.kokodo.sellerservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+    private Long sellerId;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/shop/kokodo/sellerservice/dto/SignupRequest.java
+++ b/src/main/java/shop/kokodo/sellerservice/dto/SignupRequest.java
@@ -1,0 +1,29 @@
+package shop.kokodo.sellerservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+
+    private String userLoginId;
+    private String userPassWord;
+    private String phone;
+    private String email;
+    private Boolean phoneAgree;
+    private Boolean emailAgree;
+    private String birthday;
+    private String name;
+    private Long balance;
+    private String rePos;
+    private String releasePos;
+    private String reCourier;
+    private String retailCourier;
+    private Boolean returnAgree;
+    private Boolean retailAgree;
+    private String grade;
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/entity/Seller.java
+++ b/src/main/java/shop/kokodo/sellerservice/entity/Seller.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.util.List;
+import shop.kokodo.sellerservice.dto.SignupRequest;
 
 @Entity
 @Getter
@@ -71,5 +72,24 @@ public class Seller extends BaseEntity{
         this.returnAgree = returnAgree;
         this.retailAgree = retailAgree;
         this.grade = grade;
+    }
+
+    public Seller (SignupRequest dto, String encryptedPassword) {
+        this.userLoginId = dto.getUserLoginId();
+        this.userPassWord = encryptedPassword;
+        this.phone = dto.getPhone();
+        this.email = dto.getEmail();
+        this.phoneAgree = dto.getPhoneAgree();
+        this.emailAgree = dto.getEmailAgree();
+        this.birthday = dto.getBirthday();
+        this.name = dto.getName();
+        this.balance = dto.getBalance();
+        this.rePos = dto.getRePos();
+        this.releasePos = dto.getReleasePos();
+        this.reCourier = dto.getReCourier();
+        this.retailCourier = dto.getRetailCourier();
+        this.returnAgree = dto.getReturnAgree();
+        this.retailAgree = dto.getRetailAgree();
+        this.grade = dto.getGrade();
     }
 }

--- a/src/main/java/shop/kokodo/sellerservice/repository/SellerRepository.java
+++ b/src/main/java/shop/kokodo/sellerservice/repository/SellerRepository.java
@@ -1,5 +1,6 @@
 package shop.kokodo.sellerservice.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.kokodo.sellerservice.entity.Seller;
 
@@ -16,5 +17,6 @@ import shop.kokodo.sellerservice.entity.Seller;
  */
 public interface SellerRepository extends JpaRepository<Seller, Long> {
 
+    Optional<Seller> findByUserLoginId(String userLoginId);
 
 }

--- a/src/main/java/shop/kokodo/sellerservice/security/JwtTokenCreator.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/JwtTokenCreator.java
@@ -1,0 +1,42 @@
+package shop.kokodo.sellerservice.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenCreator {
+
+    @Value("${token.seller.access.exp}")
+    public Long ACCESS_TOKEN_EXP_TIME;
+
+    @Value("${token.seller.refresh.exp}")
+    public Long REFRESH_TOKEN_EXP_TIME;
+
+    @Value("${token.seller.secret}")
+    private String jwtTokenSecret;
+
+    public String generateAccessToken(Long memberId) {
+        Map<String, Object> claims = new HashMap<>();
+
+        return Jwts.builder().setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setSubject(Long.toString(memberId))
+                .signWith(SignatureAlgorithm.HS512, jwtTokenSecret)
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXP_TIME)).compact();
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Map<String, Object> claims = new HashMap<>();
+
+        return Jwts.builder().setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setSubject(Long.toString(memberId))
+                .signWith(SignatureAlgorithm.HS512, jwtTokenSecret)
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXP_TIME)).compact();
+    }
+}

--- a/src/main/java/shop/kokodo/sellerservice/security/LoginAuthenticationFilter.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/LoginAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package shop.kokodo.sellerservice.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+import shop.kokodo.sellerservice.dto.LoginRequest;
+import shop.kokodo.sellerservice.dto.LoginResponse;
+
+@Component
+@Slf4j
+public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtTokenCreator jwtTokenCreator;
+
+    private final ObjectMapper objectMapper;
+
+
+    public LoginAuthenticationFilter(AuthenticationManager authenticationManager,
+        JwtTokenCreator jwtTokenCreator,
+        ObjectMapper objectMapper) {
+        super.setAuthenticationManager(authenticationManager);
+        this.objectMapper = objectMapper;
+        this.jwtTokenCreator = jwtTokenCreator;
+    }
+
+    //인증수행 로직
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        try{
+            LoginRequest creds = new ObjectMapper().readValue(request.getInputStream(), LoginRequest.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            creds.getLoginId(),
+                            creds.getPassword()
+                    )
+            );
+        } catch(IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //인증 성공 로직
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain chain,
+                                            Authentication authResult) throws IOException {
+
+        UserDetailsImpl userDetails = ( ((UserDetailsImpl) authResult.getPrincipal()));
+        Long sellerId = userDetails.getId();
+
+        //JWT Token 생성
+        String accessToken = jwtTokenCreator.generateAccessToken(sellerId);
+        String refreshToken = jwtTokenCreator.generateRefreshToken(sellerId);
+
+        // 바디에 토큰 및 회원 ID 저장.
+        LoginResponse respLogin = new LoginResponse(sellerId, accessToken, refreshToken);
+        response.getWriter().write(objectMapper.writeValueAsString(respLogin));
+    }
+}

--- a/src/main/java/shop/kokodo/sellerservice/security/UserDetailsImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/UserDetailsImpl.java
@@ -1,0 +1,60 @@
+package shop.kokodo.sellerservice.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import shop.kokodo.sellerservice.entity.Seller;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final Seller seller;
+
+    public UserDetailsImpl(Seller seller) {
+        this.seller = seller;
+    }
+
+    public Seller getSeller() {
+        return seller;
+    }
+
+
+    public Long getId() {
+        return seller.getId();
+    }
+
+    @Override
+    public String getPassword() {
+        return seller.getUserPassWord();
+    }
+
+    @Override
+    public String getUsername() {
+        return seller.getUserLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/shop/kokodo/sellerservice/security/UserDetailsServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package shop.kokodo.sellerservice.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import shop.kokodo.sellerservice.entity.Seller;
+import shop.kokodo.sellerservice.repository.SellerRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final SellerRepository sellerRepository;
+
+    public UserDetailsServiceImpl(
+        SellerRepository sellerRepository) {
+        this.sellerRepository = sellerRepository;
+    }
+
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Seller seller = sellerRepository.findByUserLoginId(loginId)
+            .orElseThrow(() ->  new IllegalArgumentException("등록되지 않은 사용자입니다."));
+
+        return new UserDetailsImpl(seller);
+    }
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/security/WebSecurityConfig.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/WebSecurityConfig.java
@@ -1,0 +1,59 @@
+package shop.kokodo.sellerservice.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
+
+    // Security 설정
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.csrf().disable();
+        http.headers().frameOptions().disable();
+        http.httpBasic().disable();
+        http.cors().configurationSource(corsConfigurationSource());
+
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+            .authorizeRequests().antMatchers("/**").permitAll()
+            .anyRequest().authenticated();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("http://localhost:9090");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+    @Override
+    @Bean
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
@@ -9,4 +9,6 @@ public interface SellerService {
     Optional<Seller> findBySellerId(Long sellerId);
 
     Seller createSeller(SignupRequest req);
+
+    String getSellerName(Long sellerId);
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerService.java
@@ -1,10 +1,12 @@
 package shop.kokodo.sellerservice.service;
 
-import shop.kokodo.sellerservice.entity.Seller;
-
 import java.util.Optional;
+import shop.kokodo.sellerservice.dto.SignupRequest;
+import shop.kokodo.sellerservice.entity.Seller;
 
 public interface SellerService {
 
-    public Optional<Seller> findBySellerId(Long sellerId);
+    Optional<Seller> findBySellerId(Long sellerId);
+
+    Seller createSeller(SignupRequest req);
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
@@ -41,4 +41,11 @@ public class SellerServiceImpl implements SellerService{
         sellerRepository.save(newSeller);
         return newSeller;
     }
+
+    @Override
+    public String getSellerName(Long sellerId) {
+        Seller seller = sellerRepository.findById(sellerId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 판매자입니다."));
+        return seller.getName();
+    }
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/SellerServiceImpl.java
@@ -1,7 +1,9 @@
 package shop.kokodo.sellerservice.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import shop.kokodo.sellerservice.dto.SignupRequest;
 import shop.kokodo.sellerservice.entity.Seller;
 import shop.kokodo.sellerservice.repository.SellerRepository;
 
@@ -12,13 +14,31 @@ public class SellerServiceImpl implements SellerService{
 
     private final SellerRepository sellerRepository;
 
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
     @Autowired
-    public SellerServiceImpl(SellerRepository sellerRepository) {
+    public SellerServiceImpl(SellerRepository sellerRepository,
+        BCryptPasswordEncoder bCryptPasswordEncoder) {
         this.sellerRepository = sellerRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
     }
 
     @Override
     public Optional<Seller> findBySellerId(Long sellerId) {
         return sellerRepository.findById(sellerId);
+    }
+
+    @Override
+    public Seller createSeller(SignupRequest req) {
+        // 이미 등록된 로그인 아이디인 경우
+        Optional<Seller> seller = sellerRepository.findByUserLoginId(req.getUserLoginId());
+        if (seller.isPresent()) {
+            throw new IllegalArgumentException("이미 사용중인 아이디입니다.");
+        }
+
+        String encryptedPassword = bCryptPasswordEncoder.encode(req.getUserPassWord());
+        Seller newSeller = new Seller(req, encryptedPassword);
+        sellerRepository.save(newSeller);
+        return newSeller;
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,16 +1,10 @@
-insert into seller(created_date, last_modified_date, seller_id, user_long_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
-values(now(), now(),1, "namhyeop1", "!namhyeop1234", "010-3333-3333",
-       "namhyeop@gmail.com", true, true, "1996-12-12",
-       "KIMNAMHYEOP", 100000, "서울특별시 강남구", "서울특별시 강동구",
-       "롯데택배", "롯데택배", true, true,
-       "VIP");
+INSERT INTO seller (`seller_id`,`created_date`,`last_modified_date`,`balance`,`birthday`,`email`,`email_agree`,`grade`,`name`,`phone`,`phone_agree`,`re_courier`,`re_pos`,`release_pos`,`retail_agree`,`retail_courier`,`return_agree`,`user_login_id`,`user_pass_word`)
+VALUES (1,'2022-11-10 14:37:42.701119','2022-11-10 14:37:42.701119',100000,'1996-12-12','namhyeop@seller.kokodo.shop',true,'VIP','협이의 스토어','010-1234-1234',true,'롯데택배','서울특별시 강동구','서울특별시 강동구',true,'롯데택배',true,'namhyeop','$2a$10$OJtF.ZyDlRO3X0iyH1OR/OnYSU3oWxLs8Ac.5a/h9WhzXnrCDpn.S');
 
-insert into seller(created_date, last_modified_date, seller_id, user_long_id, user_pass_word, phone, email, phone_agree, email_agree, birthday, name,balance, re_pos, release_pos, re_courier, retail_courier, return_agree, retail_agree, grade)
-values(now(), now(),2, "namhyeop2", "!namhyeop1234", "010-3333-3333",
-       "namhyeop@gmail.com", true, true, "1996-12-12",
-       "KIMNAMHYEOP2", 100000, "서울특별시 강남구", "서울특별시 강동구",
-       "롯데택배", "롯데택배", true, true,
-       "VIP");
+INSERT INTO seller (`seller_id`,`created_date`,`last_modified_date`,`balance`,`birthday`,`email`,`email_agree`,`grade`,`name`,`phone`,`phone_agree`,`re_courier`,`re_pos`,`release_pos`,`retail_agree`,`retail_courier`,`return_agree`,`user_login_id`,`user_pass_word`)
+VALUES (2,'2022-11-10 14:38:32.638555','2022-11-10 14:38:32.638555',100000,'1998-08-15','nayeon@seller.kokodo.shop',true,'VIP','나연의 스토어','010-5678-56789',true,'롯데택배','서울특별시 송파구','서울특별시 송파구',true,'롯데택배',true,'nayeon','$2a$10$rrQdq4.e0Wg6hxjOEmQUw.xLNNW0RsoedZ.VzjYo8oRB8A7B8mGIq');
+
+
 
 insert into commission_policy(id,seller_id, basic, delivery_support, discount_support, etc, first_payment_delivery, medium_company_cost_refund, sales_promotion, created_date, last_modified_date)
  values(1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.0, now(), now());


### PR DESCRIPTION
# 설명
* seller 회원가입 및 로그인을 구현했습니다.
* 회원가입 API 를 통해 판매자 데이터를 생성하여 DB에 저장하고, insert 문을 추출했습니다.
* 로그인은 Spring Security 필터를 통해 구현했습니다.
* 판매자와 회원의 인증 방식을 구분함에 따라 JWT secret 값이 추가됐습니다. application.yml 에 아래와 같이 추가했습니다.

```
token:
  seller:
    access:
      exp: 86400000
    refresh:
      exp: 604800000
    secret: seller_token
```