### PR TITLE
Feat: 주문관련 판매자 대시보드 조회 API 작성

### DIFF
--- a/src/main/java/shop/kokodo/sellerservice/client/OrderServiceClient.java
+++ b/src/main/java/shop/kokodo/sellerservice/client/OrderServiceClient.java
@@ -1,0 +1,13 @@
+package shop.kokodo.sellerservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="order-service", path = "/orders/feign")
+public interface OrderServiceClient {
+
+    @GetMapping("/seller/{sellerId}/dashboard/todayCount")
+    Long getTodayOrderCount(@PathVariable Long sellerId);
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/client/OrderServiceClient.java
+++ b/src/main/java/shop/kokodo/sellerservice/client/OrderServiceClient.java
@@ -10,4 +10,7 @@ public interface OrderServiceClient {
     @GetMapping("/seller/{sellerId}/dashboard/todayCount")
     Long getTodayOrderCount(@PathVariable Long sellerId);
 
+    @GetMapping("/seller/{sellerId}/productId")
+    Long[] getMonthlyOrderCount(@PathVariable Long sellerId);
+
 }

--- a/src/main/java/shop/kokodo/sellerservice/controller/OrderController.java
+++ b/src/main/java/shop/kokodo/sellerservice/controller/OrderController.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shop.kokodo.sellerservice.dto.order.MonthlyOrderCountDto;
 import shop.kokodo.sellerservice.dto.response.Response;
 import shop.kokodo.sellerservice.service.OrderService;
 
@@ -23,4 +24,9 @@ public class OrderController {
         return Response.success(todayOrderCount);
     }
 
+    @GetMapping("/monthlyCount")
+    public Response getMonthlyOrderCount(@RequestHeader Long sellerId) {
+        Long[] monthlyOrderCount = orderService.getMonthlyOrderCount(sellerId);
+        return Response.success(monthlyOrderCount);
+    }
 }

--- a/src/main/java/shop/kokodo/sellerservice/controller/OrderController.java
+++ b/src/main/java/shop/kokodo/sellerservice/controller/OrderController.java
@@ -1,0 +1,26 @@
+package shop.kokodo.sellerservice.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.kokodo.sellerservice.dto.response.Response;
+import shop.kokodo.sellerservice.service.OrderService;
+
+@RestController
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping("/todayCount")
+    public Response getTodayOrderCount(@RequestHeader Long sellerId) {
+        Long todayOrderCount = orderService.getTodayOrderCount(sellerId);
+        return Response.success(todayOrderCount);
+    }
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/dto/order/MonthlyOrderCountDto.java
+++ b/src/main/java/shop/kokodo/sellerservice/dto/order/MonthlyOrderCountDto.java
@@ -1,0 +1,22 @@
+package shop.kokodo.sellerservice.dto.order;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class MonthlyOrderCountDto {
+    private Long janCount;
+    private Long febCount;
+    private Long marCount;
+    private Long aprCount;
+    private Long mayCount;
+    private Long junCount;
+    private Long julCount;
+    private Long augCount;
+    private Long septCount;
+    private Long octCount;
+    private Long novCount;
+    private Long decCount;
+}

--- a/src/main/java/shop/kokodo/sellerservice/security/WebSecurityConfig.java
+++ b/src/main/java/shop/kokodo/sellerservice/security/WebSecurityConfig.java
@@ -33,7 +33,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOriginPattern("http://localhost:9090");
+        configuration.addAllowedOriginPattern("*");
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);

--- a/src/main/java/shop/kokodo/sellerservice/service/OrderService.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/OrderService.java
@@ -1,0 +1,7 @@
+package shop.kokodo.sellerservice.service;
+
+public interface OrderService {
+
+    Long getTodayOrderCount(Long sellerId);
+
+}

--- a/src/main/java/shop/kokodo/sellerservice/service/OrderService.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/OrderService.java
@@ -1,7 +1,10 @@
 package shop.kokodo.sellerservice.service;
 
+import shop.kokodo.sellerservice.dto.order.MonthlyOrderCountDto;
+
 public interface OrderService {
 
     Long getTodayOrderCount(Long sellerId);
 
+    Long[] getMonthlyOrderCount(Long sellerId);
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/OrderServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/OrderServiceImpl.java
@@ -16,4 +16,9 @@ public class OrderServiceImpl implements OrderService {
     public Long getTodayOrderCount(Long sellerId) {
         return orderServiceClient.getTodayOrderCount(sellerId);
     }
+
+    @Override
+    public Long[] getMonthlyOrderCount(Long sellerId) {
+        return orderServiceClient.getMonthlyOrderCount(sellerId);
+    }
 }

--- a/src/main/java/shop/kokodo/sellerservice/service/OrderServiceImpl.java
+++ b/src/main/java/shop/kokodo/sellerservice/service/OrderServiceImpl.java
@@ -1,0 +1,19 @@
+package shop.kokodo.sellerservice.service;
+
+import org.springframework.stereotype.Service;
+import shop.kokodo.sellerservice.client.OrderServiceClient;
+
+@Service
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderServiceClient orderServiceClient;
+
+    public OrderServiceImpl(OrderServiceClient orderServiceClient) {
+        this.orderServiceClient = orderServiceClient;
+    }
+
+    @Override
+    public Long getTodayOrderCount(Long sellerId) {
+        return orderServiceClient.getTodayOrderCount(sellerId);
+    }
+}


### PR DESCRIPTION
# 설명
* 당일 주문건수, 월별 주문건수 차트 조회 API 를 작성했습니다.
* seller service -> order service -> product service 3 서비스를 조회합니다.
* 추후 OrderProduct 에서 sellerId 를 가지도록 반정규화가 필요한거 같습니다.